### PR TITLE
feat: Claude CodeでBedrock Claude Sonnet 4の429エラー解決記事を追加

### DIFF
--- a/articles/d7de82614e2f0b.md
+++ b/articles/d7de82614e2f0b.md
@@ -8,7 +8,7 @@ published: false
 
 ## はじめに
 
-Claude CodeでAWS BedrockのClaude Sonnet 4を使用していると、並列実行時に「429 Too many tokens」エラーが頻発する問題に遭遇することがありませんか？
+Claude CodeでAWS BedrockのClaude Sonnet 4を使用していると、並列実行時に「429 Too many tokens」エラーが頻発する問題に遭遇することがありませんか？同じような事象に直面する方を想定読書とします。
 
 私も実際にこの問題に悩まされ、調査した結果、緩和方法を見つけることができました。この記事では、その原因と緩和方法について詳しく解説します。
 
@@ -20,20 +20,20 @@ Claude CodeでAWS BedrockのClaude Sonnet 4を使用していると、並列実�
 
 ## 経緯・発生した問題
 
-Claude CodeでBedrock Claude Sonnet 4を使用する際、以下のような症状が発生しました：
+Claude CodeでBedrock Claude Sonnet 4を使用する際、以下のような症状が発生しました。
 
 - 単発のリクエストは正常に動作する
-- 並列でリクエストを送信すると429エラーが発生
-- 「hi」のような簡単なプロンプトでもエラーになる
-- Claude Sonnet 3.5では同じ設定で問題なく動作する
+  - ただし、会話を続けていると429エラーが発生
+- 並列でリクエストを送信するとすぐに429エラーが発生
+- 簡単なプロンプトでもエラーになる
 
 ## 原因：Token Burndown Rateの仕組み
 
-この問題の根本原因は、Claude 4シリーズ特有の**Token Burndown Rate**にありました。
+この問題の根本原因は、Claude 4シリーズ特有の**Token Burndown Rate**にあると考えます。
 
 ### Token Burndown Rateとは
 
-Token Burndown Rateは、APIの使用量がクォータ制限に対してどのようにカウントされるかを決定する仕組みです。重要なのは、これは**料金計算ではなく、クォータ消費の計算**だということですね。
+Token Burndown Rateは、APIの使用量がクォータ制限に対してどのようにカウントされるかを決定する仕組みです。重要なのは、これは**料金計算ではなく、クォータ消費の計算**だということです。
 
 ### Claude 4の特殊な仕組み
 
@@ -44,8 +44,7 @@ Token Burndown Rateは、APIの使用量がクォータ制限に対してどの�
 | その他のBedrockモデル | 1:1 | 1:1 |
 
 **Claude 4では、出力トークン1つにつき5倍のクォータが消費されます。**
-
-これが429エラーの主な原因だったんですね。
+ref: https://docs.aws.amazon.com/bedrock/latest/userguide/quotas.html#quotas-increase
 
 ### 具体例
 
@@ -61,52 +60,9 @@ Token Burndown Rateは、APIの使用量がクォータ制限に対してどの�
 - 残りクォータ: 0トークン（次の分まで待機が必要）
 ```
 
-## max_tokensの罠
-
-さらに問題を複雑にしているのが、AWS Bedrockの**事前クォータ予約**システムです。
-
-### 問題のあるコード例
-
-```javascript
-// 俳句を書いてもらうだけなのに...
-const response = await bedrock_runtime.invoke_model({
-  modelId: 'us.anthropic.claude-sonnet-4-20250514-v1:0',
-  body: JSON.dumps({
-    'anthropic_version': 'bedrock-2023-05-31',
-    'max_tokens': 4000, // 高すぎる！
-    'messages': [{
-      'role': 'user',
-      'content': 'Write a haiku about clouds'
-    }]
-  })
-});
-
-// 実際の使用: ~15トークン = 75クォータ
-// しかし予約されるクォータ: 4,000 × 5 = 20,000クォータ！
-```
-
-### 改善されたコード例
-
-```javascript
-const response = await bedrock_runtime.invoke_model({
-  modelId: 'us.anthropic.claude-sonnet-4-20250514-v1:0',
-  body: JSON.dumps({
-    'anthropic_version': 'bedrock-2023-05-31',
-    'max_tokens': 50, // 現実的な値
-    'messages': [{
-      'role': 'user', 
-      'content': 'Write a haiku about clouds'
-    }]
-  })
-});
-
-// 予約されるクォータ: 50 × 5 = 250クォータ
-// 並列リクエストが可能！
-```
-
 ## 対応方法
 
-Claude Codeでこの問題を緩和するには、`CLAUDE_CODE_MAX_OUTPUT_TOKENS`環境変数を設定することで緩和できます。
+Claude Codeでこの問題を緩和するには、`CLAUDE_CODE_MAX_OUTPUT_TOKENS`環境変数を設定することが私の環境においては有効でした。
 
 ### 設定方法
 
@@ -114,12 +70,10 @@ Claude Codeでこの問題を緩和するには、`CLAUDE_CODE_MAX_OUTPUT_TOKENS
 
 ```json
 {
-  "model": "us.anthropic.claude-sonnet-4-20250514-v1:0",
-  "provider": "bedrock",
   "env": {
     "CLAUDE_CODE_USE_BEDROCK": "true",
     "ANTHROPIC_MODEL": "us.anthropic.claude-sonnet-4-20250514-v1:0",
-    "CLAUDE_CODE_MAX_OUTPUT_TOKENS": "1024"
+    "CLAUDE_CODE_MAX_OUTPUT_TOKENS": 1024
   },
   "permissions": {
     "allow": [
@@ -130,44 +84,14 @@ Claude Codeでこの問題を緩和するには、`CLAUDE_CODE_MAX_OUTPUT_TOKENS
 }
 ```
 
-### 推奨値
-
-- **1024**: 基本的な用途に適している
-- **2048**: より長い応答が必要な場合
-- **4096**: 大きなコード生成が必要な場合
-
-**注意**: 値を大きくしすぎると再び429エラーが発生する可能性があります。
-
-## 地域設定の重要性
-
-Bedrock Claude 4を使用する際は、地域設定も重要です：
-
-- **推奨地域**: `us-west-2`
-- **理由**: 他の地域では制限が厳しいか、モデルが利用できない場合がある
-
-## 実際の制限値
-
-テストの結果、以下の制限が確認されています：
-
-### Claude Sonnet 4
-- **公式最大値**: 64,000トークン
-- **実際の制限**: 39,200トークン以下
-- **推奨値**: 1024-4096トークン
-
-### Claude Opus 4  
-- **最大値**: 32,000トークン
-- **注意**: 成功してもエラーが同時に発生する場合がある
-
 ## まとめ
 
 Claude CodeでBedrock Claude Sonnet 4の429 too many tokensエラーを緩和するポイントは以下の通りです：
 
 1. **Token Burndown Rate**を理解する（出力トークンは5倍消費）
 2. **`CLAUDE_CODE_MAX_OUTPUT_TOKENS`**を適切に設定する
-3. **地域を`us-west-2`**に設定する
-4. **並列実行時は特に低い値**から始める
 
-この設定により、Claude CodeでBedrock Claude Sonnet 4のエラー頻度を大幅に緩和できるようになりました。ただし、長時間の使用では依然として制限に達する可能性があるため、用途に応じて値を調整することが重要ですね。
+この設定により、Claude CodeでBedrock Claude Sonnet 4のエラー頻度を大幅に緩和できるようになりました。
 
 同じ問題で困っている方の参考になれば幸いです。
 

--- a/articles/d7de82614e2f0b.md
+++ b/articles/d7de82614e2f0b.md
@@ -1,5 +1,5 @@
 ---
-title: "Claude CodeでBedrock Claude Sonnet 4の429エラーを解決してみた"
+title: "Claude CodeでBedrock Claude Sonnet 4の429 too many tokensエラーを緩和してみた"
 emoji: "💨"
 type: "tech" # tech: 技術記事 / idea: アイデア
 topics: ["Claude Code", "Bedrock", "AI", "AWS"]
@@ -10,7 +10,7 @@ published: false
 
 Claude CodeでAWS BedrockのClaude Sonnet 4を使用していると、並列実行時に「429 Too many tokens」エラーが頻発する問題に遭遇することがありませんか？
 
-私も実際にこの問題に悩まされ、調査した結果、解決方法を見つけることができました。この記事では、その原因と解決方法について詳しく解説します。
+私も実際にこの問題に悩まされ、調査した結果、緩和方法を見つけることができました。この記事では、その原因と緩和方法について詳しく解説します。
 
 ## 前提・環境
 
@@ -106,7 +106,7 @@ const response = await bedrock_runtime.invoke_model({
 
 ## 対応方法
 
-Claude Codeでこの問題を解決するには、`CLAUDE_CODE_MAX_OUTPUT_TOKENS`環境変数を設定することで解決できます。
+Claude Codeでこの問題を緩和するには、`CLAUDE_CODE_MAX_OUTPUT_TOKENS`環境変数を設定することで緩和できます。
 
 ### 設定方法
 
@@ -160,14 +160,14 @@ Bedrock Claude 4を使用する際は、地域設定も重要です：
 
 ## まとめ
 
-Claude CodeでBedrock Claude Sonnet 4の429エラーを解決するポイントは以下の通りです：
+Claude CodeでBedrock Claude Sonnet 4の429 too many tokensエラーを緩和するポイントは以下の通りです：
 
 1. **Token Burndown Rate**を理解する（出力トークンは5倍消費）
 2. **`CLAUDE_CODE_MAX_OUTPUT_TOKENS`**を適切に設定する
 3. **地域を`us-west-2`**に設定する
 4. **並列実行時は特に低い値**から始める
 
-この設定により、Claude CodeでBedrock Claude Sonnet 4を安定して使用できるようになりました。ただし、長時間の使用では依然として制限に達する可能性があるため、用途に応じて値を調整することが重要ですね。
+この設定により、Claude CodeでBedrock Claude Sonnet 4のエラー頻度を大幅に緩和できるようになりました。ただし、長時間の使用では依然として制限に達する可能性があるため、用途に応じて値を調整することが重要ですね。
 
 同じ問題で困っている方の参考になれば幸いです。
 

--- a/articles/d7de82614e2f0b.md
+++ b/articles/d7de82614e2f0b.md
@@ -1,0 +1,177 @@
+---
+title: "Claude CodeでBedrock Claude Sonnet 4の429エラーを解決してみた"
+emoji: "💨"
+type: "tech" # tech: 技術記事 / idea: アイデア
+topics: ["Claude Code", "Bedrock", "AI", "AWS"]
+published: false
+---
+
+## はじめに
+
+Claude CodeでAWS BedrockのClaude Sonnet 4を使用していると、並列実行時に「429 Too many tokens」エラーが頻発する問題に遭遇することがありませんか？
+
+私も実際にこの問題に悩まされ、調査した結果、解決方法を見つけることができました。この記事では、その原因と解決方法について詳しく解説します。
+
+## 前提・環境
+
+- Claude Code（旧Claude CLI）を使用
+- AWS Bedrock経由でClaude Sonnet 4を利用
+- 並列でのリクエスト実行を想定
+
+## 経緯・発生した問題
+
+Claude CodeでBedrock Claude Sonnet 4を使用する際、以下のような症状が発生しました：
+
+- 単発のリクエストは正常に動作する
+- 並列でリクエストを送信すると429エラーが発生
+- 「hi」のような簡単なプロンプトでもエラーになる
+- Claude Sonnet 3.5では同じ設定で問題なく動作する
+
+## 原因：Token Burndown Rateの仕組み
+
+この問題の根本原因は、Claude 4シリーズ特有の**Token Burndown Rate**にありました。
+
+### Token Burndown Rateとは
+
+Token Burndown Rateは、APIの使用量がクォータ制限に対してどのようにカウントされるかを決定する仕組みです。重要なのは、これは**料金計算ではなく、クォータ消費の計算**だということですね。
+
+### Claude 4の特殊な仕組み
+
+| モデル | Input Token Rate | Output Token Rate |
+|--------|------------------|-------------------|
+| Claude Sonnet 4 | 1:1 | **1:5** |
+| Claude Opus 4 | 1:1 | **1:5** |
+| その他のBedrockモデル | 1:1 | 1:1 |
+
+**Claude 4では、出力トークン1つにつき5倍のクォータが消費されます。**
+
+これが429エラーの主な原因だったんですね。
+
+### 具体例
+
+100,000 TPM（tokens per minute）のクォータがある場合：
+
+```
+シナリオ1: 10,000出力トークンを生成
+- クォータ消費: 10,000 × 5 = 50,000トークン
+- 残りクォータ: 50,000トークン
+
+シナリオ2: 20,000出力トークンを生成  
+- クォータ消費: 20,000 × 5 = 100,000トークン
+- 残りクォータ: 0トークン（次の分まで待機が必要）
+```
+
+## max_tokensの罠
+
+さらに問題を複雑にしているのが、AWS Bedrockの**事前クォータ予約**システムです。
+
+### 問題のあるコード例
+
+```javascript
+// 俳句を書いてもらうだけなのに...
+const response = await bedrock_runtime.invoke_model({
+  modelId: 'us.anthropic.claude-sonnet-4-20250514-v1:0',
+  body: JSON.dumps({
+    'anthropic_version': 'bedrock-2023-05-31',
+    'max_tokens': 4000, // 高すぎる！
+    'messages': [{
+      'role': 'user',
+      'content': 'Write a haiku about clouds'
+    }]
+  })
+});
+
+// 実際の使用: ~15トークン = 75クォータ
+// しかし予約されるクォータ: 4,000 × 5 = 20,000クォータ！
+```
+
+### 改善されたコード例
+
+```javascript
+const response = await bedrock_runtime.invoke_model({
+  modelId: 'us.anthropic.claude-sonnet-4-20250514-v1:0',
+  body: JSON.dumps({
+    'anthropic_version': 'bedrock-2023-05-31',
+    'max_tokens': 50, // 現実的な値
+    'messages': [{
+      'role': 'user', 
+      'content': 'Write a haiku about clouds'
+    }]
+  })
+});
+
+// 予約されるクォータ: 50 × 5 = 250クォータ
+// 並列リクエストが可能！
+```
+
+## 対応方法
+
+Claude Codeでこの問題を解決するには、`CLAUDE_CODE_MAX_OUTPUT_TOKENS`環境変数を設定することで解決できます。
+
+### 設定方法
+
+`~/.claude/settings.json`を以下のように設定：
+
+```json
+{
+  "model": "us.anthropic.claude-sonnet-4-20250514-v1:0",
+  "provider": "bedrock",
+  "env": {
+    "CLAUDE_CODE_USE_BEDROCK": "true",
+    "ANTHROPIC_MODEL": "us.anthropic.claude-sonnet-4-20250514-v1:0",
+    "CLAUDE_CODE_MAX_OUTPUT_TOKENS": "1024"
+  },
+  "permissions": {
+    "allow": [
+      "Bash(aws configure:*)"
+    ],
+    "deny": []
+  }
+}
+```
+
+### 推奨値
+
+- **1024**: 基本的な用途に適している
+- **2048**: より長い応答が必要な場合
+- **4096**: 大きなコード生成が必要な場合
+
+**注意**: 値を大きくしすぎると再び429エラーが発生する可能性があります。
+
+## 地域設定の重要性
+
+Bedrock Claude 4を使用する際は、地域設定も重要です：
+
+- **推奨地域**: `us-west-2`
+- **理由**: 他の地域では制限が厳しいか、モデルが利用できない場合がある
+
+## 実際の制限値
+
+テストの結果、以下の制限が確認されています：
+
+### Claude Sonnet 4
+- **公式最大値**: 64,000トークン
+- **実際の制限**: 39,200トークン以下
+- **推奨値**: 1024-4096トークン
+
+### Claude Opus 4  
+- **最大値**: 32,000トークン
+- **注意**: 成功してもエラーが同時に発生する場合がある
+
+## まとめ
+
+Claude CodeでBedrock Claude Sonnet 4の429エラーを解決するポイントは以下の通りです：
+
+1. **Token Burndown Rate**を理解する（出力トークンは5倍消費）
+2. **`CLAUDE_CODE_MAX_OUTPUT_TOKENS`**を適切に設定する
+3. **地域を`us-west-2`**に設定する
+4. **並列実行時は特に低い値**から始める
+
+この設定により、Claude CodeでBedrock Claude Sonnet 4を安定して使用できるようになりました。ただし、長時間の使用では依然として制限に達する可能性があるため、用途に応じて値を調整することが重要ですね。
+
+同じ問題で困っている方の参考になれば幸いです。
+
+## 参考資料
+
+- [AWS Community: Why Claude 4 API Hits Rate Limits](https://community.aws/content/2xVZmCM5E7XXw0yqTEGgXYxRowk/bedrock-claude-4-burndown-rates)
+- [GitHub Issue: Claude CLI not working with sonnet 4 in bedrock](https://github.com/anthropics/claude-code/issues/1293)

--- a/articles/d7de82614e2f0b.md
+++ b/articles/d7de82614e2f0b.md
@@ -3,7 +3,7 @@ title: "Claude CodeでBedrock Claude Sonnet 4の429 too many tokensエラーを�
 emoji: "💨"
 type: "tech" # tech: 技術記事 / idea: アイデア
 topics: ["Claude Code", "Bedrock", "AI", "AWS"]
-published: false
+published: true
 ---
 
 ## はじめに


### PR DESCRIPTION
# Claude CodeでBedrock Claude Sonnet 4の429エラー解決記事を追加

## 概要
Claude CodeでAWS BedrockのClaude Sonnet 4を使用する際に発生する「429 Too many tokens」エラーの原因と解決方法をまとめた技術記事を追加しました。

## 記事の内容
- **問題**: 並列実行時に429エラーが頻発する現象
- **原因**: Claude 4特有のToken Burndown Rate（出力トークン1つにつき5倍のクォータ消費）
- **解決方法**: `CLAUDE_CODE_MAX_OUTPUT_TOKENS`環境変数の適切な設定
- **ベストプラクティス**: 推奨値と地域設定の重要性

## 技術的なポイント
- Token Burndown Rateの仕組みの詳細解説
- AWS Bedrockの事前クォータ予約システムの説明
- 実際のテスト結果に基づく制限値の情報
- コード例による具体的な改善方法の提示

## 参考資料
- AWS Community記事とGitHub issueから得られた知見を整理
- 実際に問題に遭遇した開発者の報告を基に作成

## 対象読者
- Claude CodeでBedrock Claude Sonnet 4を使用している開発者
- 429エラーに悩まされている方
- Token制限について理解を深めたい方

この記事により、同じ問題に遭遇した開発者が迅速に解決策を見つけられるようになります。
